### PR TITLE
feat: add export utils

### DIFF
--- a/src/ts/demo.ts
+++ b/src/ts/demo.ts
@@ -5,6 +5,7 @@ import BufferQueue from "./BufferQueue.js";
 import secureMPC from "./secureMPC.js";
 import { IO } from "./types";
 import assert from './assert.js';
+import { channelFromByte } from "./utils.js";
 
 const windowAny = window as any;
 
@@ -196,17 +197,6 @@ async function makeWebSocketIO(url: string, otherParty: number) {
   sock.onclose = () => io.close();
 
   return io;
-}
-
-function channelFromByte(byte: number): 'a' | 'b' {
-  switch (byte) {
-    case 'a'.charCodeAt(0):
-      return 'a';
-    case 'b'.charCodeAt(0):
-      return 'b';
-    default:
-      throw new Error('Invalid channel');
-  }
 }
 
 async function makePeerIO(pairingCode: string, party: number) {

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Converts a byte value to a channel identifier.
+ * @param byte - The byte value to convert
+ * @returns The channel identifier ('a' or 'b')
+ * @throws {Error} If the byte doesn't correspond to a valid channel
+ */
+export function channelFromByte(byte: number): 'a' | 'b' {
+  switch (byte) {
+    case 'a'.charCodeAt(0):
+      return 'a';
+    case 'b'.charCodeAt(0):
+      return 'b';
+    default:
+      throw new Error('Invalid channel');
+  }
+}
+
+/**
+ * Converts a channel identifier to its byte representation.
+ * @param channel - The channel identifier ('a' or 'b')
+ * @returns The byte representation of the channel
+ * @throws {Error} If the channel is invalid
+ */
+export function byteFromChannel(channel: 'a' | 'b'): number {
+  switch (channel) {
+    case 'a':
+      return 'a'.charCodeAt(0);
+    case 'b':
+      return 'b'.charCodeAt(0);
+    default:
+      throw new Error('Invalid channel');
+  }
+}


### PR DESCRIPTION
## What is this PR doing?
This PR adds a new utility file `(src/ts/utils.ts)` that provides functions for converting between channel identifiers ('a' or 'b') and their byte representations. The file includes two main functions:

`channelFromByte():` Converts a byte value to a channel identifier
`byteFromChannel():` Converts a channel identifier to its byte representation
Both functions include proper TypeScript typing, error handling for invalid inputs, and JSDoc documentation.

## How can these changes be manually tested?

- Import the utility functions in your code: `import { channelFromByte, byteFromChannel } from '../ts/utils'`
- Test the conversion from byte to channel: `const channel = channelFromByte('a'.charCodeAt(0))`
- Test the conversion from channel to byte: `const byte = byteFromChannel('a')`
- Verify error handling by passing invalid values to both functions

## Does this PR resolve or contribute to any issues?

PR related to MPC Framework issue - https://github.com/privacy-scaling-explorations/mpc-framework/issues/10
